### PR TITLE
fix: change options to opt on postForm request to GBPrimePay

### DIFF
--- a/src/lib/GBPrimePay.ts
+++ b/src/lib/GBPrimePay.ts
@@ -139,7 +139,7 @@ export class GBPrimePay {
   
     const r = await this.$http.postForm(
       GBPrimePayApiUrl[channel],
-      options
+      opt
     )
 
     if (!this.raw) {


### PR DESCRIPTION
~~Because token, checksum or publicKey won't get sent through the request if we straight using `options`~~

As per other peoples viewing the source code might be confused when we called the original `options` object without knowing that `opt`  can reference back to it